### PR TITLE
Add create_use_ option

### DIFF
--- a/lib/devise-kerberos-authenticatable.rb
+++ b/lib/devise-kerberos-authenticatable.rb
@@ -10,6 +10,9 @@ module Devise
   #Kerberos realm to use
   mattr_accessor :kerberos_realm
   @@kerberos_realm = ""
+
+  mattr_accessor :kerberos_create_user
+  @@ldap_create_user = true
 end
 
 Devise.add_module(

--- a/lib/devise_kerberos_authenticatable/model.rb
+++ b/lib/devise_kerberos_authenticatable/model.rb
@@ -27,18 +27,15 @@ module Devise
           auth_key_value = (self.strip_whitespace_keys || []).include?(auth_key) ? auth_key_value.strip : auth_key_value
 
           resource = where(auth_key => auth_key_value).first
-
           if resource.blank?
             resource = new
             resource[auth_key] = auth_key_value
           end
 
-          if resource.try(:valid_kerberos_authentication?, attributes[:password])
-            resource.save if resource.new_record?
-            return resource
-          else
-            return nil
+          if ::Devise.kerberos_create_user && resource.new_record? && resource.valid_kerberos_authentication?(attributes[:password])
+            resource.save!
           end
+          resource
         end
       end
     end


### PR DESCRIPTION
When kerberos_create_user option is set, the new user is added to user model, otherwise, the authentication will fail.
